### PR TITLE
feat: remote MCP @ AWS — HTTP-transport, read-only, health, kontti, paikkatietotyökalut

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Virtuaaliympäristö ja git
+.venv/
+.git/
+.gitignore
+.gitattributes
+
+# Rajausaineistot (299 MB) — EI tarvita MCP-tooleissa ajonaikaisesti
+data/boundaries/
+
+# SQLite-sivutiedostot (vain päätiedosto data/aura.db kopioidaan)
+data/aura.db-shm
+data/aura.db-wal
+
+# Testit ja kehitysartefaktit
+tests/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+**/__pycache__/
+*.pyc
+.playwright-mcp/
+
+# Output ja dokumentaatio (ei ajonaikaista)
+output/
+docs/
+contributions/
+scripts/
+
+# IDE/editor
+.vscode/
+.idea/
+.claude/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Aura remote MCP -server (read-only, streamable HTTP) — App Runner -kontti.
+# Vain ajonaikaiset riippuvuudet + data/aura.db (ei boundaries-gpkg:itä).
+FROM python:3.11-slim
+
+# Ei .pyc-tiedostoja, stdout/err puskuroimatta (lokit CloudWatchiin reaaliajassa)
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+# 1) Asenna riippuvuudet (cacheystävällinen: vain metadata ensin).
+#    Editable-asennus pitää src/auran import-paikkana, jolloin
+#    DEFAULT_DB_PATH (= __file__/../../../data/aura.db) osoittaa /app/data/aura.db.
+COPY pyproject.toml README.md ./
+COPY src ./src
+RUN pip install -e .
+
+# 2) Kopioi tietokanta (ajonaikainen riippuvuus). Boundaries jätetään pois.
+COPY data/aura.db ./data/aura.db
+
+# 3) Read-only remote on oletus tälle imagelle.
+ENV AURA_READONLY=1
+
+# 4) Aja non-root-käyttäjänä.
+RUN useradd --create-home --uid 10001 app && chown -R app:app /app
+USER app
+
+EXPOSE 8000
+CMD ["aura", "serve", "--http", "--host", "0.0.0.0", "--port", "8000"]

--- a/data/aura.db
+++ b/data/aura.db
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:846b4a29fd0aa3ca4f25256f13fe4a2e222c05d959d84b67dbd81e10422ddff6
-size 90611712
+oid sha256:50c816ed7ffb56ebf69d0a5d069ba1dbe20048152f4e2946923012b9132b1597
+size 90628096

--- a/docs/superpowers/specs/2026-06-06-aws-remote-mcp-design.md
+++ b/docs/superpowers/specs/2026-06-06-aws-remote-mcp-design.md
@@ -76,6 +76,21 @@ asiakas (Claude, ChatGPT ym.) voi käyttää Auraa ilman repon kloonausta.
 - **(Valinnainen) Route 53 + ACM** — custom domain ja sertifikaatti, esim. `mcp.aura.fi`.
 - **(Roadmap, vaihe 2) S3** — `aura.db`:n jakelu ilman image-rebuildia.
 
+### 3.1 Julkitaho-näkökulma (kohde + portability)
+
+Palvelu on tulossa julkiselle taholle; lopullista AWS-tiliä, domainia ja toteutustapaa ei ole vielä
+sovittu. Tämä **ei muuta v1-suositusta** (App Runner), mutta huomioidaan:
+
+- **EU-region / dataresidenssi:** valitaan EU-region (eu-west-1 Irlanti tai eu-central-1 Frankfurt;
+  **huom:** App Runner ei välttämättä ole eu-north-1 Tukholmassa — varmistettava region-valinnassa).
+  Data on avointa julkista dataa ja read-only, joten residenssi ei ole kriittinen, mutta hyvä käytäntö.
+- **Tilin omistus / landing zone:** jos julkitaho hostaa palvelun omassa AWS-organisaatiossaan, heidän
+  guardrailinsa (sallitut palvelut, pakollinen VPC, tagit, verkkorakenne) voivat ohjata valintaa.
+- **Portability on suunnittelun kantava periaate:** koska palvelu on **kontti** (stateless, read-only,
+  yksi `/mcp`-endpoint), se siirtyy sellaisenaan App Runnerista ECS Fargateen / EKS:ään / julkitahon
+  landing zoneen **ilman sovellusmuutoksia**. Region ja tili ovat Terraform-muuttujia. → App Runner on
+  turvallinen ja nopea v1-valinta, joka ei lukitse pois julkitahon mahdollisia vaatimuksia.
+
 ## 4. Komponenttisuunnittelu
 
 ### 4.1 HTTP-transport-moodi
@@ -158,9 +173,11 @@ Pieni, luettava moduulisetti `infra/`-kansioon:
 - `dns.tf` (valinnainen) — ACM-sertti + custom domain App Runnerille.
 - `variables.tf` / `outputs.tf` — region, image-tag, domain; output: palvelun URL.
 
-Tila: Terraform-state remote backendissä (S3 + DynamoDB lock) **tai** alkuun lokaali/manuaalinen apply
-(ei salaisuuksia → state ei sisällä avaimia, mutta voi sisältää ARN-tunnisteita; pidetään state pois
-julkisesta reposta).
+**Salassapito (julkinen repo):** mitään AWS-tunnistetta ei kovakoodata reposovittuun koodiin.
+Arkaluontoiset arvot (account id, region, OIDC-rooli-ARN, ECR-URI, domain) annetaan `*.tfvars`-
+tiedostona joka on **.gitignoressa**. Terraform-state private S3-backendissä (+ DynamoDB lock) —
+ei koskaan julkiseen repoon. `.gitignore`: `*.tfvars`, `.terraform/`, `*.tfstate*`,
+`.terraform.lock.hcl` (lock voi jäädä, mutta state ei).
 
 > Vaihtoehto: AWS CDK (Python) jos halutaan infra samalla kielellä kuin projekti. Valittu Terraform
 > "helppo + kypsä App Runner -tuki" -syystä. Päätös kirjataan issueen.
@@ -169,12 +186,18 @@ julkisesta reposta).
 
 Workflow `.github/workflows/deploy.yml`:
 
-1. **Trigger:** push `main`-haaraan tai release-tagiin (päätetään issuessa; oletus: tag-pohjainen
-   tuotantodeploy, jotta jokainen harvest-commit ei deployaa).
-2. **Auth:** `aws-actions/configure-aws-credentials` OIDC:llä → lyhytikäinen rooli. Ei secrets-storea.
-3. **Build & push:** Docker build → tag (git SHA + `latest`) → push ECR:ään.
-4. **Deploy:** App Runner auto-deploy (tai eksplisiittinen `start-deployment` -API-kutsu).
-5. **(Valinnainen) Smoke test:** deployn jälkeen kutsu `/health` ja yksi MCP-`stats`-kutsu.
+1. **Trigger:** **vain `workflow_dispatch`** (manuaalinen, eksplisiittinen "oma deployment-triggeri").
+   Ei auto-deployta pushista eikä App Runnerin auto-deploya. Deploy ajetaan Actions-napista tai
+   `gh workflow run deploy.yml`. Suojataan **GitHub Environmentilla** (`production`), joka voi vaatia
+   hyväksynnän ennen ajoa.
+2. **Salassapito (julkinen repo):** kaikki AWS-tunnisteet (account id, region, OIDC-rooli-ARN, ECR-URI,
+   domain) tallennetaan **GitHub Actions secrets/variables** -muotoon (yksityisiä myös julkisessa
+   repossa) tai suojattuun Environmentiin — **ei koskaan koodiin**.
+3. **Auth:** `aws-actions/configure-aws-credentials` OIDC:llä → lyhytikäinen rooli. Ei secrets-storea
+   pitkäikäisille avaimille.
+4. **Build & push:** Docker build → tag (git SHA + `latest`) → push ECR:ään.
+5. **Deploy:** eksplisiittinen App Runner `start-deployment` -API-kutsu (auto-deploy pois).
+6. **(Valinnainen) Smoke test:** deployn jälkeen kutsu `/health` ja yksi MCP-`stats`-kutsu.
 
 Erillinen `ci.yml` (jos ei jo): ruff + mypy + pytest PR:issä (ei AWS-riippuvuutta).
 

--- a/docs/superpowers/specs/2026-06-06-aws-remote-mcp-design.md
+++ b/docs/superpowers/specs/2026-06-06-aws-remote-mcp-design.md
@@ -189,6 +189,30 @@ nykyistä lokaalikäyttöä (ei enää riippuvuutta gpkg-tiedostoista perusrajau
 - **Suunnitellaan jo v1:ssä:** käynnistyslataaja kirjoitetaan niin, että S3-lähde on pelkkä
   env-muuttuja → vaihe 2 on additiivinen, ei refaktorointia.
 
+### 5.3 Tietokantateknologia ja skaalautuvuus
+
+**Kysymys:** pitäisikö SQLite korvata skaalautuvammalla AWS-kannalla (RDS/Aurora/DynamoDB)?
+
+**Päätös: ei v1:ssä.** Read-only-käyttöön bundlattu SQLite on tässä työkuormassa *skaalautuvin* ja
+halvin vaihtoehto, ei pullonkaula:
+
+- **87 MB mahtuu RAM/page-cacheen.** Jokaisella instanssilla oma kopio → nollakontentio, ei
+  yhteyspoolia, ei verkkolatenssia. Lukukapasiteetti kasvaa lineaarisesti instanssimäärän mukana.
+  Jaettu RDS/Aurora olisi tähän askel taaksepäin (yksi pullonkaula + verkkohyppy + kiinteä kustannus + ops).
+- **FTS5-suomihaku on ydintä.** Postgres vaatisi haun uudelleenkirjoituksen (`tsvector`/`pg_trgm`,
+  eri ranking); DynamoDB:ssä ei täystekstihakua lainkaan (vaatisi OpenSearchin). Iso työ ilman hyötyä
+  read-only-skenaariossa.
+- **Kustannus/ops:** SQLite 0 €/kk, ei patchattavaa.
+
+**Migraatiotriggerit (milloin skaalautuva kanta on perusteltu):**
+1. **Pilvikirjoitukset / joukkoistus** (roadmap #5) — jaettu kirjoitustila. Ainoa vahva ajuri; v1:ssä rajattu pois.
+2. **Datasetti kasvaa monen GB:n kokoiseksi** → ensin vaihe 2 (DB S3:sta), vasta sitten Postgres/Aurora.
+3. **Semanttinen haku (embeddings)** → Postgres + `pgvector` tai OpenSearch. Aito pitkän linjan syy.
+
+**Migraatiopolku, jos trigger osuu:** pidetään `database.py` ainoana data-access-rajana, jolloin
+vaihto on rajattu. Kandidaatit: **Aurora Serverless v2 (Postgres + FTS/pgvector)** read-painotteiseen,
+tai **DynamoDB + OpenSearch** jos kirjoitukset + haku eriytetään. Arvioidaan omana spec:nä silloin.
+
 ## 6. IaC — Terraform
 
 Pieni, luettava moduulisetti `infra/`-kansioon:

--- a/docs/superpowers/specs/2026-06-06-aws-remote-mcp-design.md
+++ b/docs/superpowers/specs/2026-06-06-aws-remote-mcp-design.md
@@ -92,6 +92,27 @@ sovittu. Tämä **ei muuta v1-suositusta** (App Runner), mutta huomioidaan:
   landing zoneen **ilman sovellusmuutoksia**. Region ja tili ovat Terraform-muuttujia. → App Runner on
   turvallinen ja nopea v1-valinta, joka ei lukitse pois julkitahon mahdollisia vaatimuksia.
 
+### 3.2 Sopiiko App Runner MCP-backendiin? (vs. EC2-välivaihe)
+
+**Kyllä — stateless streamable HTTP:lle.** MCP streamable HTTP = HTTP request/response + SSE-striimaus
+vastauksessa, **ei WebSocketteja**. App Runner ei tue WebSocketteja, mutta MCP ei niitä tarvitse → ei
+ongelma. Stateless-moodissa pyynnöt ovat lyhyitä ja riippumattomia → autoscaling toimii puhtaasti.
+*Implementaatiossa varmistettava:* App Runnerin request-timeout-asetus + SSE-striimaus toimii läpi.
+
+**EC2-välivaihe MVP:nä — "meneekö App Runner tukkoon tarpeettomasti"?**
+- **Throughput ei ole ongelma kummallakaan.** Read-only 87 MB SQLite RAMissa, FTS-kyselyt
+  millisekuntteja. Pieni EC2 (t4g.micro ~6 $/kk) jaksaa valtavasti lukukyselyitä; ei "mene tukkoon"
+  normaaliliikenteellä — eikä App Runner.
+- **Ero on ops-taakassa, ei suorituskyvyssä.** EC2 siirtää sinulle TLS-sertit (nginx/caddy + Let's
+  Encrypt), prosessin valvonnan, OS-patchauksen, uptimen ja kovennuksen — julkiselle avoimelle
+  endpointille isompi hyökkäyspinta ja jatkuvaa käsityötä.
+- **App Runner antaa hallitun HTTPS:n, autoscalingin, health checkin ja nollan OS-ylläpidon**;
+  deploy = pushaa image. Idle-kustannus matala (~muutama $/kk).
+
+**Päätös:** App Runner on MVP. EC2 olisi *enemmän* toilia, ei vähemmän. Poikkeus: pelkkä päästä-päähän
+**pikavalidointi** ennen IaC:ta voidaan tehdä kertakäyttöisellä EC2:lla tai lokaalilla tunnelilla
+(`cloudflared`/`ngrok`); varsinainen MVP menee App Runneriin.
+
 ## 4. Komponenttisuunnittelu
 
 ### 4.1 HTTP-transport-moodi

--- a/docs/superpowers/specs/2026-06-06-aws-remote-mcp-design.md
+++ b/docs/superpowers/specs/2026-06-06-aws-remote-mcp-design.md
@@ -26,7 +26,8 @@ asiakas (Claude, ChatGPT ym.) voi käyttää Auraa ilman repon kloonausta.
 - Web-palvelun (FastAPI `aura web`) hostaus — eri elinkaari, käsitellään myöhemmin (ks. roadmap).
 - Remote-kirjoitukset / joukkoistus pilvessä.
 - OAuth / käyttäjäkohtaisuus.
-- Boundaries-gpkg-tiedostojen (299 MB) vienti pilveen — ei tarvita MCP-tooleissa ajonaikaisesti.
+- Boundaries-gpkg-tiedostojen (299 MB) vienti pilveen — ei tarvita: paikkatieto tarjotaan
+  kannasta MCP-työkaluilla (ks. §4.6), ei gpkg-tiedostoista.
 
 ## 2. Lähtötilanteen havainnot
 
@@ -123,10 +124,37 @@ Ohjataan env-muuttujalla `AURA_READONLY=1` (asetetaan App Runnerissa):
 
 `server.py`:n `instructions`-teksti viittaa local-FS:ään (`data/boundaries/*.gpkg`). Remote-moodissa:
 
-- Pudotetaan FS-pohjaiset boundaries-ohjeet ja korvataan ohjeella, että karttalehti-/kuntatiedot
-  haetaan kannasta (`ref_map_sheets`, `ref_municipalities`) tai tulevasta MCP-toolista.
+- Korvataan FS-pohjaiset boundaries-ohjeet ohjeella käyttää **§4.6:n paikkatietotyökaluja**, jotka
+  palvelevat saman tiedon kannasta (`ref_map_sheets` bbox jo valmiina). Agentti saa siis saman
+  paikkatieto-osaamisen ilman tiedostojärjestelmää.
 - Säilytetään rajapintojen suora käyttö -ohje (query_data toimii remotessa, koska outbound HTTP).
 - Toteutus: `build_instructions(readonly: bool) -> str` tai kaksi vakiota.
+
+### 4.6 Paikkatietotyökalut MCP:ssä (spatial enrichment)
+
+**Tavoite (käyttäjän toive):** agentti osaa hyödyntää Auran valmista paikkatietoa — rajata
+kyselyjä kohderajapintoihin (WFS/WCS/OGC) alueella ja ymmärtää mitä "paikkatieto" tarkoittaa
+kussakin yhteydessä. Esim. *"millaisia tietoja meillä on karttalehdeltä L4133?"* → Aura palauttaa
+lehden bbox:n + osaa rajata datakyselyt sille alueelle. Tämä toimii **täysin kannasta**, joten se
+sopii read-only-remoteen.
+
+**Data-valmius:**
+- `ref_map_sheets` sisältää **jo** bbox:n (`min_x/min_y/max_x/max_y`), centroidin, mittakaavan ja
+  hierarkkisen tunnuksen (`id`, esim. `L4133A`) → karttalehtirajaus heti mahdollista.
+- `ref_municipalities` **ei** sisällä bbox:ia → tarvitaan pieni offline-populaattorilisäys (bbox-sarakkeet
+  + täyttö `kuntajako_1000k.gpkg`:sta). Sama mekanismi kuin `ref_map_sheets` sai bbox:nsa.
+
+**Uudet read-only-toolit (palvelevat kannasta):**
+- `map_sheet(id)` — palauttaa karttalehden bbox:n (EPSG:3067), centroidin ja mittakaavan; valmis
+  WFS/WCS-`bbox`-parametriksi.
+- `find_map_sheets(bbox | point | municipality, scale)` — mitkä lehdet osuvat alueelle; lisäksi
+  hierarkkinen rajaus tunnus-prefiksillä (esim. kaikki `L413%` -lehdet halutulla mittakaavalla).
+- `municipality_bbox(name | code)` — kunnan bbox aluerajaukseen (vaatii populaattorilisäyksen).
+- *(Harkittava)* `query_data`:n laajennus: valinnainen `map_sheet`/`municipality`-parametri, joka
+  muuntaa alueen bbox:ksi ja syöttää sen WFS/OGC-kyselyyn automaattisesti → "rikastaa kyselyn targettiin".
+
+**Hyöty:** sama paikkatieto-osaaminen toimii sekä lokaalisti että remotessa, ja se hyödyttää myös
+nykyistä lokaalikäyttöä (ei enää riippuvuutta gpkg-tiedostoista perusrajauksissa).
 
 ### 4.4 Kontti-image (Dockerfile)
 
@@ -243,9 +271,9 @@ Vaiheistettu, kukin oma epic/spec myöhemmin:
 2. **Web-palvelun hostaus** (`aura web`): sama kontti tai erillinen App Runner -service; staattinen
    build CloudFront+S3:een tai SSR App Runnerissa. Oma elinkaari.
 3. **Väärinkäytön esto:** CloudFront + WAF rate-limiting jos avoin endpoint sitä vaatii.
-4. **Karttalehti-/boundary-MCP-toolit:** korvataan local-FS-ohjeet oikeilla tooleilla
-   (`map_sheet_bbox`, `municipality_bbox`) jotka palvelevat `ref_*`-tauluista — hyödyttää myös
-   lokaalikäyttöä.
+4. **Paikkatietotyökalujen laajennus:** §4.6:n peruskalut (map_sheet, find_map_sheets,
+   municipality_bbox) ovat v1:ssä. Laajennus: `query_data`-rikastus alueparametrilla, hierarkkinen
+   lehtinavigointi, point-in-polygon-haut tarkemmalla `kuntajako_10k`-aineistolla.
 5. **Remote-kirjoitukset / joukkoistus:** jos halutaan crowdsourcing pilvessä → erillinen kirjoitus-store
    (DynamoDB tai EFS-SQLite) tai PR-pohjainen kontribuutio. Vaatii oman suunnittelun.
 6. **OAuth / käyttäjäkohtaisuus:** MCP-spec OAuth jos tarvitaan kiintiöitä per käyttäjä.
@@ -258,11 +286,13 @@ Epic: **AWS deployment (remote MCP)**. Issuet karkeassa riippuvuusjärjestyksess
 
 1. HTTP-transport-moodi `serve`-komentoon (`--http`, stateless).
 2. Read-only-moodi: tool-gateys + RO-SQLite + `config.is_readonly()`.
-3. Remote-instructions-variantti (ei local-FS-lupauksia).
-4. `/health`-endpoint.
-5. Dockerfile + `.dockerignore` (vain `aura.db`, ei boundaries).
-6. Terraform: ECR + App Runner + IAM OIDC (+ valinnainen domain).
-7. GitHub Actions deploy-workflow (OIDC → build → push → deploy).
-8. Observability + budjetti + smoke test.
-9. Dokumentaatio: README "Remote MCP" -osio + asiakaskonfiguraatiot.
-10. (Roadmap-issue) Vaihe 2: DB S3:sta + `aura db-publish`.
+3. Paikkatietotyökalut (§4.6): `map_sheet`, `find_map_sheets` (kannasta, valmis heti) +
+   `ref_municipalities`-bbox-populaattori + `municipality_bbox`. *(Harkittava `query_data`-laajennus.)*
+4. Remote-instructions-variantti (ohjaa §4.6-työkaluihin, ei local-FS-lupauksia).
+5. `/health`-endpoint.
+6. Dockerfile + `.dockerignore` (vain `aura.db`, ei boundaries).
+7. Terraform: ECR + App Runner + IAM OIDC (+ valinnainen domain).
+8. GitHub Actions deploy-workflow (OIDC → build → push → deploy).
+9. Observability + budjetti + smoke test.
+10. Dokumentaatio: README "Remote MCP" -osio + asiakaskonfiguraatiot.
+11. (Roadmap-issue) Vaihe 2: DB S3:sta + `aura db-publish`.

--- a/docs/superpowers/specs/2026-06-06-aws-remote-mcp-design.md
+++ b/docs/superpowers/specs/2026-06-06-aws-remote-mcp-design.md
@@ -1,0 +1,245 @@
+# Aura Remote MCP @ AWS — suunnitelma
+
+- **Päivämäärä:** 2026-06-06
+- **Tila:** Hyväksytty suunta, odottaa spec-katselmointia
+- **Tekijä:** Tero + Claude (brainstorming)
+
+## 1. Tavoite ja rajaukset
+
+Aura on tällä hetkellä paikallisesti ajettava MCP-server (FastMCP 3.x, stdio-transport).
+Tavoitteena on julkaista **remote MCP -endpoint AWS:ään**, jotta kuka tahansa MCP-yhteensopiva
+asiakas (Claude, ChatGPT ym.) voi käyttää Auraa ilman repon kloonausta.
+
+**Reunaehdot (sovittu):**
+
+- **Julkinen, avoin projekti** → ei salaisuuksia repossa missään muodossa. CI autentikoituu
+  AWS:ään OIDC:llä, ei tallennettuja avaimia.
+- **Täysin avoin pääsy** → ei API-avainta eikä OAuthia v1:ssä. Vain väärinkäytön esto (rate-limit).
+- **Read-only remote** → remote tarjoaa vain luvun. Kirjoittavat toolit (enrichment, findings-tallennus,
+  harvest, quality/schema-päivitykset) eivät ole käytössä remotessa. Rikastus tehdään lokaalisti ja
+  committataan kantaan.
+- **Helppo nyt, laajennettava myöhemmin.** Erityisesti **kannan etäpäivityksen** pitää muuttua helpoksi
+  roadmapilla ilman koodideployta.
+
+**Rajaukset (out of scope v1):**
+
+- Web-palvelun (FastAPI `aura web`) hostaus — eri elinkaari, käsitellään myöhemmin (ks. roadmap).
+- Remote-kirjoitukset / joukkoistus pilvessä.
+- OAuth / käyttäjäkohtaisuus.
+- Boundaries-gpkg-tiedostojen (299 MB) vienti pilveen — ei tarvita MCP-tooleissa ajonaikaisesti.
+
+## 2. Lähtötilanteen havainnot
+
+- **Transport:** `cli.py serve` kutsuu `mcp.run()` → stdio. Remote vaatii streamable HTTP -transportin.
+- **Ajonaikainen riippuvuus on vain `data/aura.db` (~87 MB)**, joka on jo gitissä. Boundaries-gpkg:t
+  käytetään vain offline-populaattoreissa (`populators/map_sheets.py`) ja web-apissa
+  (`web/routes/api.py`), **ei MCP-tooleissa**. Karttalehdet ovat jo `ref_map_sheets`-taulussa kannassa.
+- **Kirjoitukset kantaan** tulevat: `tools/enrichment.py`, `tools/admin.py` (harvest), `tools/quality.py`,
+  `tools/schema.py`, `tools/research.py` (save_session_findings). Nämä gateataan pois remotessa.
+- **Server-instructions** (`server.py`) lupaa agentille, että se voi lukea `data/boundaries/*.gpkg`
+  paikallisesta tiedostojärjestelmästä. Remotessa tätä FS:ää ei ole → tarvitaan remote-variantti
+  instructions-tekstistä.
+
+## 3. Arkkitehtuuri (v1)
+
+```
+                 ┌────────────────────────────────────────────┐
+   MCP-client    │  AWS                                         │
+  (Claude, GPT)  │                                              │
+       │  HTTPS  │   ┌──────────────┐      ┌───────────────┐    │
+       └────────────▶│  App Runner  │◀─────│      ECR      │    │
+        /mcp     │   │  (Aura HTTP) │ pull │  aura:<tag>   │    │
+                 │   │  read-only   │ img  └───────────────┘    │
+                 │   │  stateless   │              ▲            │
+                 │   └──────┬───────┘              │ push       │
+                 │          │ stdout/err           │            │
+                 │          ▼                       │            │
+                 │   ┌──────────────┐       ┌──────────────┐    │
+                 │   │  CloudWatch  │       │  GitHub       │    │
+                 │   │  Logs/Metrics│       │  Actions(OIDC)│    │
+                 │   └──────────────┘       └──────────────┘    │
+                 └────────────────────────────────────────────┘
+                                              ▲
+                                              │ git push (main / tag)
+                                       ┌──────────────┐
+                                       │  Dev (lokaali)│  harvest + committaa aura.db
+                                       └──────────────┘
+```
+
+**Komponentit:**
+
+- **AWS App Runner** — ajaa Aura-kontin, tarjoaa hallitun HTTPS-endpointin, autoscalingin ja
+  custom domainin. Health check `/health`-polkuun. Auto-deploy uuden ECR-imagen ilmestyessä.
+- **Amazon ECR** — kontti-imagejen rekisteri. Imageen leivottu `data/aura.db` (v1).
+- **CloudWatch** — App Runnerin lokit ja metriikat (request count, latency, 5xx).
+- **IAM OIDC -rooli** — GitHub Actions ottaa lyhytikäisen roolin (ei tallennettuja avaimia).
+- **(Valinnainen) Route 53 + ACM** — custom domain ja sertifikaatti, esim. `mcp.aura.fi`.
+- **(Roadmap, vaihe 2) S3** — `aura.db`:n jakelu ilman image-rebuildia.
+
+## 4. Komponenttisuunnittelu
+
+### 4.1 HTTP-transport-moodi
+
+`cli.py serve` saa lipun transportin valintaan:
+
+```bash
+aura serve                       # stdio (nykyinen, oletus — ei rikota mitään)
+aura serve --http --host 0.0.0.0 --port 8000   # streamable HTTP remotea varten
+```
+
+- Käytetään FastMCP:n streamable HTTP -transporttia, polku `/mcp`.
+- **Stateless-moodi päälle** (read-only horisontaalisesti skaalautuva) → ei session-tilaa instanssien
+  välillä, App Runner voi skaalata vapaasti.
+- Portti ja host konfiguroidaan env-muuttujilla (`AURA_HTTP_HOST`, `AURA_HTTP_PORT`) ja/tai lipuilla.
+
+### 4.2 Read-only-moodi
+
+Ohjataan env-muuttujalla `AURA_READONLY=1` (asetetaan App Runnerissa):
+
+- **SQLite avataan read-only** -tilassa (`file:...?mode=ro`, `immutable=1` jos kanta on muuttumaton
+  imagessa) → estää vahingossa tapahtuvat kirjoitukset jo tasolla 0.
+- **Kirjoittavat toolit eivät rekisteröidy** remote-moodissa. Toteutus: tool-rekisteröinti tarkistaa
+  moodin ja ohittaa nämä: `enrich`, `batch_enrich`, `suggest_yso_tags(save=True)`,
+  `save_session_findings`, `harvest`, `populate_reference`, `probe_sizes`, sekä quality/schema-kirjoitus.
+  (`log_finding`/`list_findings` voivat jäädä, koska ne ovat session-muistissa, mutta tallennus pois.)
+- Tämä pidetään yhdessä paikassa (esim. `aura/config.py: is_readonly()`) jottei moodilogiikka leviä.
+
+### 4.3 Remote-instructions-variantti
+
+`server.py`:n `instructions`-teksti viittaa local-FS:ään (`data/boundaries/*.gpkg`). Remote-moodissa:
+
+- Pudotetaan FS-pohjaiset boundaries-ohjeet ja korvataan ohjeella, että karttalehti-/kuntatiedot
+  haetaan kannasta (`ref_map_sheets`, `ref_municipalities`) tai tulevasta MCP-toolista.
+- Säilytetään rajapintojen suora käyttö -ohje (query_data toimii remotessa, koska outbound HTTP).
+- Toteutus: `build_instructions(readonly: bool) -> str` tai kaksi vakiota.
+
+### 4.4 Kontti-image (Dockerfile)
+
+- Pohja: `python:3.11-slim`.
+- Asennetaan vain runtime-riippuvuudet (`pip install .` ilman `dev`/`web`-extroja).
+- Kopioidaan `src/` + `data/aura.db`. **Ei** boundaries-gpkg:itä (säästää ~299 MB).
+- `.dockerignore`: `.venv`, `tests`, `data/boundaries`, `.git`, cachet, `output/`.
+- Ajaa non-root-käyttäjänä. `EXPOSE 8000`. `CMD ["aura","serve","--http","--host","0.0.0.0","--port","8000"]`.
+- Tavoite image-koko: < ~250 MB.
+
+### 4.5 Health-endpoint
+
+- Lisätään kevyt `/health` (200 OK + esim. datasettien määrä / DB-yhteyden tarkistus) FastMCP:n
+  alla olevaan Starlette-appiin. App Runner käyttää tätä health checkinä.
+
+## 5. Kannan jakelu ja päivitys
+
+### Vaihe 1 (MVP) — DB leivottu imageen
+
+- `aura.db` kopioidaan imageen build-aikana.
+- **Päivitysflow:** lokaali `harvest` → committaa `aura.db` → `git push` (main tai release-tag) →
+  GitHub Actions buildaa imagen → ECR → App Runner auto-deployaa.
+- **Edut:** atominen (kanta + koodi samassa artefaktissa), versioitu, rollback image-tagilla, nolla
+  lisäinfraa. Sopii nykyiseen "DB on gitissä" -workflowhun.
+
+### Vaihe 2 (roadmap) — DB S3:sta, lataus käynnistyksessä
+
+- Kontti lataa käynnistyessä `aura.db`:n S3:sta paikalliseen ephemeral-levyyn jos
+  `AURA_DB_S3_URI` on asetettu (muuten käyttää imageen leivottua).
+- **Päivitysflow:** `aura db-publish` lataa kannan S3:een (versioitu bucket) ja triggeröi App Runner
+  -redeployn → ei koodimuutosta, ei image-rebuildia. Repo voi lopulta lakata kantamasta 87 MB binääriä.
+- **Suunnitellaan jo v1:ssä:** käynnistyslataaja kirjoitetaan niin, että S3-lähde on pelkkä
+  env-muuttuja → vaihe 2 on additiivinen, ei refaktorointia.
+
+## 6. IaC — Terraform
+
+Pieni, luettava moduulisetti `infra/`-kansioon:
+
+- `ecr.tf` — ECR-repo (lifecycle policy vanhojen tagien siivoukseen).
+- `apprunner.tf` — App Runner -service: image ECR:stä, portti 8000, health check `/health`,
+  autoscaling (min 1, max esim. 3), env: `AURA_READONLY=1`.
+- `iam.tf` — GitHub OIDC provider + deploy-rooli (ECR push + App Runner update), App Runnerin
+  access-rooli ECR:ään.
+- `dns.tf` (valinnainen) — ACM-sertti + custom domain App Runnerille.
+- `variables.tf` / `outputs.tf` — region, image-tag, domain; output: palvelun URL.
+
+Tila: Terraform-state remote backendissä (S3 + DynamoDB lock) **tai** alkuun lokaali/manuaalinen apply
+(ei salaisuuksia → state ei sisällä avaimia, mutta voi sisältää ARN-tunnisteita; pidetään state pois
+julkisesta reposta).
+
+> Vaihtoehto: AWS CDK (Python) jos halutaan infra samalla kielellä kuin projekti. Valittu Terraform
+> "helppo + kypsä App Runner -tuki" -syystä. Päätös kirjataan issueen.
+
+## 7. CI/CD — GitHub Actions + OIDC
+
+Workflow `.github/workflows/deploy.yml`:
+
+1. **Trigger:** push `main`-haaraan tai release-tagiin (päätetään issuessa; oletus: tag-pohjainen
+   tuotantodeploy, jotta jokainen harvest-commit ei deployaa).
+2. **Auth:** `aws-actions/configure-aws-credentials` OIDC:llä → lyhytikäinen rooli. Ei secrets-storea.
+3. **Build & push:** Docker build → tag (git SHA + `latest`) → push ECR:ään.
+4. **Deploy:** App Runner auto-deploy (tai eksplisiittinen `start-deployment` -API-kutsu).
+5. **(Valinnainen) Smoke test:** deployn jälkeen kutsu `/health` ja yksi MCP-`stats`-kutsu.
+
+Erillinen `ci.yml` (jos ei jo): ruff + mypy + pytest PR:issä (ei AWS-riippuvuutta).
+
+## 8. Tietoturva ja väärinkäytön esto
+
+- **Avoin endpoint** → ei autentikointia v1. Riski: väärinkäyttö / kustannukset.
+- **Rate-limit:** App Runnerissa ei natiivia rate-limitiä. v1: luotetaan App Runnerin max-instanssirajaan
+  + CloudWatch-hälytys epätavallisesta liikenteestä. Roadmap: CloudFront + AWS WAF rate-based -sääntö
+  endpointin eteen jos väärinkäyttöä ilmenee.
+- **Read-only + stateless** → ei dataa rikottavaksi, ei session-tilaa vuodettavaksi.
+- **Ei salaisuuksia** imagessa, repossa eikä lokeissa. Outbound-kutsut (query_data) menevät julkisiin
+  avoimen datan rajapintoihin.
+- **Kustannuskatto:** AWS Budgets -hälytys.
+
+## 9. Observability
+
+- CloudWatch Logs (stdout/stderr), metriikat: request count, latency, 4xx/5xx, instanssimäärä.
+- CloudWatch-hälytykset: 5xx-piikki, poikkeava request-volyymi, kustannusbudjetti.
+
+## 10. Kustannusarvio (karkea)
+
+- App Runner: ~5–25 $/kk (min 1 pieni instanssi idlenä; skaalautuu liikenteellä).
+- ECR: muutama sentti/kk (image-tallennus).
+- CloudWatch / Route53: muutama dollari/kk.
+- **Yhteensä luokkaa ~10–30 $/kk** matalalla liikenteellä.
+
+## 11. Testaus
+
+- **Yksikkö:** read-only-gateys (kirjoittavia tooleja ei rekisteröidy kun `AURA_READONLY=1`),
+  remote-instructions-variantti, RO-SQLite-yhteys.
+- **Integraatio:** `aura serve --http` käynnistyy, `/health` vastaa 200, MCP-`initialize` +
+  `stats`-kutsu HTTP:n yli onnistuu.
+- **Kontti:** image buildaa, käynnistyy, `/health` vastaa kontissa.
+- **CI:** ruff + mypy(strict) + pytest säilyvät vihreinä.
+- Olemassa olevat testit importoivat `from aura.server import ...` → varmistetaan ettei moodilogiikka
+  riko importteja (oletus stdio + ei-readonly testeissä).
+
+## 12. Tulevaisuuden roadmap
+
+Vaiheistettu, kukin oma epic/spec myöhemmin:
+
+1. **Vaihe 2 — DB S3:sta + `aura db-publish`** (kts. §5): kannan etäpäivitys ilman koodideployta.
+2. **Web-palvelun hostaus** (`aura web`): sama kontti tai erillinen App Runner -service; staattinen
+   build CloudFront+S3:een tai SSR App Runnerissa. Oma elinkaari.
+3. **Väärinkäytön esto:** CloudFront + WAF rate-limiting jos avoin endpoint sitä vaatii.
+4. **Karttalehti-/boundary-MCP-toolit:** korvataan local-FS-ohjeet oikeilla tooleilla
+   (`map_sheet_bbox`, `municipality_bbox`) jotka palvelevat `ref_*`-tauluista — hyödyttää myös
+   lokaalikäyttöä.
+5. **Remote-kirjoitukset / joukkoistus:** jos halutaan crowdsourcing pilvessä → erillinen kirjoitus-store
+   (DynamoDB tai EFS-SQLite) tai PR-pohjainen kontribuutio. Vaatii oman suunnittelun.
+6. **OAuth / käyttäjäkohtaisuus:** MCP-spec OAuth jos tarvitaan kiintiöitä per käyttäjä.
+7. **MCP-rekisteröinti:** listaus julkisiin MCP-hakemistoihin (julkaisija hankittu) kun endpoint vakaa.
+8. **Monialueisuus / korkea saatavuus:** App Runner on jo moni-AZ; useampi region vasta jos tarve.
+
+## 13. Toteutusjärjestys (epic → issuet)
+
+Epic: **AWS deployment (remote MCP)**. Issuet karkeassa riippuvuusjärjestyksessä:
+
+1. HTTP-transport-moodi `serve`-komentoon (`--http`, stateless).
+2. Read-only-moodi: tool-gateys + RO-SQLite + `config.is_readonly()`.
+3. Remote-instructions-variantti (ei local-FS-lupauksia).
+4. `/health`-endpoint.
+5. Dockerfile + `.dockerignore` (vain `aura.db`, ei boundaries).
+6. Terraform: ECR + App Runner + IAM OIDC (+ valinnainen domain).
+7. GitHub Actions deploy-workflow (OIDC → build → push → deploy).
+8. Observability + budjetti + smoke test.
+9. Dokumentaatio: README "Remote MCP" -osio + asiakaskonfiguraatiot.
+10. (Roadmap-issue) Vaihe 2: DB S3:sta + `aura db-publish`.

--- a/docs/superpowers/specs/2026-06-06-aws-remote-mcp-design.md
+++ b/docs/superpowers/specs/2026-06-06-aws-remote-mcp-design.md
@@ -69,7 +69,7 @@ asiakas (Claude, ChatGPT ym.) voi käyttää Auraa ilman repon kloonausta.
 **Komponentit:**
 
 - **AWS App Runner** — ajaa Aura-kontin, tarjoaa hallitun HTTPS-endpointin, autoscalingin ja
-  custom domainin. Health check `/health`-polkuun. Auto-deploy uuden ECR-imagen ilmestyessä.
+  custom domainin. Health check `/health`-polkuun. Deploy laukaistaan eksplisiittisesti (auto-deploy pois).
 - **Amazon ECR** — kontti-imagejen rekisteri. Imageen leivottu `data/aura.db` (v1).
 - **CloudWatch** — App Runnerin lokit ja metriikat (request count, latency, 5xx).
 - **IAM OIDC -rooli** — GitHub Actions ottaa lyhytikäisen roolin (ei tallennettuja avaimia).
@@ -147,8 +147,8 @@ Ohjataan env-muuttujalla `AURA_READONLY=1` (asetetaan App Runnerissa):
 ### Vaihe 1 (MVP) — DB leivottu imageen
 
 - `aura.db` kopioidaan imageen build-aikana.
-- **Päivitysflow:** lokaali `harvest` → committaa `aura.db` → `git push` (main tai release-tag) →
-  GitHub Actions buildaa imagen → ECR → App Runner auto-deployaa.
+- **Päivitysflow:** lokaali `harvest` → committaa `aura.db` → `git push` → kun halutaan julkaista,
+  laukaistaan manuaalinen deploy-triggeri → GitHub Actions buildaa imagen → ECR → App Runner -deploy.
 - **Edut:** atominen (kanta + koodi samassa artefaktissa), versioitu, rollback image-tagilla, nolla
   lisäinfraa. Sopii nykyiseen "DB on gitissä" -workflowhun.
 

--- a/scripts/migrations/017_municipality_bbox.sql
+++ b/scripts/migrations/017_municipality_bbox.sql
@@ -1,0 +1,7 @@
+-- Kuntien bbox (EPSG:3067) aluerajauksiin — populoidaan kuntajako_1000k.gpkg:sta
+-- (populator: municipality_bbox). Nullable kunnes populoitu.
+
+ALTER TABLE ref_municipalities ADD COLUMN min_x REAL;
+ALTER TABLE ref_municipalities ADD COLUMN min_y REAL;
+ALTER TABLE ref_municipalities ADD COLUMN max_x REAL;
+ALTER TABLE ref_municipalities ADD COLUMN max_y REAL;

--- a/src/aura/cli.py
+++ b/src/aura/cli.py
@@ -341,8 +341,9 @@ def main() -> None:
 
     elif args.command == "serve":
         from aura.serve import resolve_serve_config
-        from aura.server import mcp
+        from aura.server import apply_readonly_gating, mcp
 
+        apply_readonly_gating(mcp)
         cfg = resolve_serve_config(http=args.http, host=args.host, port=args.port)
         mcp.run(**cfg.run_args())
 

--- a/src/aura/cli.py
+++ b/src/aura/cli.py
@@ -40,7 +40,19 @@ def main() -> None:
     )
 
     # serve
-    subparsers.add_parser("serve", help="Käynnistä MCP-server")
+    serve_parser = subparsers.add_parser("serve", help="Käynnistä MCP-server")
+    serve_parser.add_argument(
+        "--http", action="store_true",
+        help="Aja streamable HTTP -transportilla (remote MCP) stdion sijaan",
+    )
+    serve_parser.add_argument(
+        "--host", default=None,
+        help="HTTP-host (oletus: AURA_HTTP_HOST tai 127.0.0.1)",
+    )
+    serve_parser.add_argument(
+        "--port", type=int, default=None,
+        help="HTTP-portti (oletus: AURA_HTTP_PORT tai 8000)",
+    )
 
     # search
     search_parser = subparsers.add_parser("search", help="Hae datasettejä")
@@ -328,9 +340,11 @@ def main() -> None:
             print(f"Laatupisteet laskettu {qcount} datasetille.")
 
     elif args.command == "serve":
+        from aura.serve import resolve_serve_config
         from aura.server import mcp
 
-        mcp.run()
+        cfg = resolve_serve_config(http=args.http, host=args.host, port=args.port)
+        mcp.run(**cfg.run_args())
 
     elif args.command == "search":
         from aura.database import get_connection, init_db, search_datasets

--- a/src/aura/config.py
+++ b/src/aura/config.py
@@ -1,0 +1,22 @@
+"""Ajonaikainen konfiguraatio (#135).
+
+Yksi paikka moodilogiikalle (read-only remote vs. täysi lokaalikäyttö).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def is_readonly(env: Mapping[str, str] | None = None) -> bool:
+    """Onko server read-only-moodissa (remote)?
+
+    Ohjataan ``AURA_READONLY``-ympäristömuuttujalla. Read-only-moodissa
+    kirjoittavat toolit eivät rekisteröidy ja tietokanta avataan vain luettavaksi.
+    """
+    if env is None:
+        env = os.environ
+    return env.get("AURA_READONLY", "").strip().lower() in _TRUTHY

--- a/src/aura/database.py
+++ b/src/aura/database.py
@@ -23,6 +23,7 @@ def get_connection(
     db_path: Path = DEFAULT_DB_PATH,
     *,
     check_same_thread: bool = True,
+    readonly: bool = False,
 ) -> sqlite3.Connection:
     """Avaa tietokantayhteys.
 
@@ -30,7 +31,16 @@ def get_connection(
         db_path: Polku tietokantatiedostoon.
         check_same_thread: Jos False, sallii yhteyden käytön eri threadeista.
             Turvallista WAL-moden kanssa read-heavy käytössä (esim. MCP-server).
+        readonly: Jos True, avaa yhteys vain luettavaksi (``mode=ro``). Estää
+            kaikki kirjoitukset jo SQLite-tasolla (remote read-only -moodi).
     """
+    if readonly:
+        # mode=ro: ei mkdiriä eikä WAL-pragmaa (ne kirjoittaisivat levylle).
+        uri = f"file:{db_path}?mode=ro"
+        conn = sqlite3.connect(uri, uri=True, check_same_thread=check_same_thread)
+        conn.row_factory = sqlite3.Row
+        return conn
+
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(db_path), check_same_thread=check_same_thread)
     conn.row_factory = sqlite3.Row

--- a/src/aura/populators/__init__.py
+++ b/src/aura/populators/__init__.py
@@ -6,6 +6,7 @@ from aura.populators.base import BasePopulator
 from aura.populators.boundaries import BoundaryPopulator
 from aura.populators.map_sheets import MapSheetPopulator
 from aura.populators.municipalities import MunicipalityPopulator
+from aura.populators.municipality_bbox import MunicipalityBboxPopulator
 from aura.populators.postal_codes import PostalCodePopulator
 
 # Rekisteri kaikista populaattoreista
@@ -14,6 +15,7 @@ POPULATORS: dict[str, type[BasePopulator]] = {
     "postal_codes": PostalCodePopulator,
     "boundaries": BoundaryPopulator,
     "map_sheets": MapSheetPopulator,
+    "municipality_bbox": MunicipalityBboxPopulator,
 }
 
 

--- a/src/aura/populators/municipality_bbox.py
+++ b/src/aura/populators/municipality_bbox.py
@@ -1,0 +1,80 @@
+"""Kuntien bbox (EPSG:3067) — MML:n kuntajako_1000k.gpkg:sta ref_municipalities-tauluun.
+
+Lukee Kunta-tason geometrioiden envelope-bbox:t (sama GPKG-parseri kuin
+map_sheets) ja päivittää olemassa olevat kunnat natcode = code -avaimella.
+Ei-destruktiivinen: ei kosketa kuntien muihin kenttiin.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+from aura.populators.base import BasePopulator
+from aura.populators.map_sheets import _parse_gpkg_envelope
+
+logger = logging.getLogger(__name__)
+
+GPKG_PATH = Path("data/boundaries/kuntajako_1000k.gpkg")
+
+# (min_x, min_y, max_x, max_y)
+Bbox = tuple[float, float, float, float]
+
+
+class MunicipalityBboxPopulator(BasePopulator):
+    """Populoi kuntien bbox-tiedot ref_municipalities-tauluun GeoPackagesta."""
+
+    name = "municipality_bbox"
+    description = "Kuntien bbox (EPSG:3067) aluerajauksiin"
+    source_url = "MML kuntajako_1000k.gpkg"
+
+    async def populate(self) -> int:
+        """Lue kuntien bbox:t GeoPackagesta ja päivitä tietokantaan."""
+        mapping = self._read_bboxes()
+        return self._apply_bboxes(mapping)
+
+    def _read_bboxes(self) -> dict[str, Bbox]:
+        """Lue {kuntakoodi: bbox} kuntajako-GeoPackagen Kunta-tasolta."""
+        if not GPKG_PATH.exists():
+            msg = (
+                f"GeoPackage puuttuu: {GPKG_PATH}. "
+                "Lataa MML:n kuntajako_1000k.gpkg (ks. README)."
+            )
+            raise FileNotFoundError(msg)
+
+        gpkg = sqlite3.connect(str(GPKG_PATH))
+        try:
+            rows = gpkg.execute(
+                "SELECT natcode, multipolygon FROM Kunta WHERE natcode IS NOT NULL"
+            ).fetchall()
+        finally:
+            gpkg.close()
+
+        mapping: dict[str, Bbox] = {}
+        for natcode, blob in rows:
+            bbox = _parse_gpkg_envelope(blob)
+            if bbox is None:
+                continue
+            mapping[str(natcode).zfill(3)] = bbox
+        return mapping
+
+    def _apply_bboxes(self, mapping: dict[str, Bbox]) -> int:
+        """Päivitä kuntien bbox-sarakkeet. Palauttaa päivitettyjen rivien määrän."""
+        updated = 0
+        for code, (min_x, min_y, max_x, max_y) in mapping.items():
+            cur = self.conn.execute(
+                """
+                UPDATE ref_municipalities
+                SET min_x = ?, min_y = ?, max_x = ?, max_y = ?
+                WHERE code = ?
+                """,
+                (min_x, min_y, max_x, max_y, code),
+            )
+            updated += cur.rowcount
+        self.conn.commit()
+        version = datetime.now(UTC).strftime("%Y-%m-%d")
+        self._update_metadata(updated, version=version)
+        logger.info("[%s] Päivitetty %d kunnan bbox", self.name, updated)
+        return updated

--- a/src/aura/serve.py
+++ b/src/aura/serve.py
@@ -1,0 +1,76 @@
+"""Serve-komennon transport-konfiguraation resoluutio (#134).
+
+Eristää päätöslogiikan (stdio vs. streamable HTTP, host/portti) blokkaavasta
+``mcp.run()``-kutsusta, jotta se on yksikkötestattavissa.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+DEFAULT_PATH = "/mcp"
+
+
+@dataclass(frozen=True)
+class ServeConfig:
+    """Resoluoitu serve-konfiguraatio.
+
+    ``run_args()`` palauttaa suoraan ``mcp.run(**kwargs)``-yhteensopivan dictin.
+    """
+
+    transport: str
+    host: str | None = None
+    port: int | None = None
+    path: str | None = None
+    stateless_http: bool = False
+
+    def run_args(self) -> dict[str, Any]:
+        if self.transport == "stdio":
+            return {"transport": "stdio"}
+        return {
+            "transport": self.transport,
+            "host": self.host,
+            "port": self.port,
+            "path": self.path,
+            "stateless_http": self.stateless_http,
+        }
+
+
+def resolve_serve_config(
+    *,
+    http: bool,
+    host: str | None = None,
+    port: int | None = None,
+    env: Mapping[str, str] | None = None,
+) -> ServeConfig:
+    """Resoluoi serve-konfiguraatio argumenteista ja ympäristömuuttujista.
+
+    Eksplisiittiset argumentit voittavat env-muuttujat, jotka voittavat oletukset.
+    """
+    if env is None:
+        env = os.environ
+
+    if not http:
+        return ServeConfig(transport="stdio")
+
+    resolved_host = host or env.get("AURA_HTTP_HOST") or DEFAULT_HOST
+
+    if port is not None:
+        resolved_port = port
+    elif env.get("AURA_HTTP_PORT"):
+        resolved_port = int(env["AURA_HTTP_PORT"])
+    else:
+        resolved_port = DEFAULT_PORT
+
+    return ServeConfig(
+        transport="http",
+        host=resolved_host,
+        port=resolved_port,
+        path=DEFAULT_PATH,
+        stateless_http=True,
+    )

--- a/src/aura/server.py
+++ b/src/aura/server.py
@@ -278,4 +278,5 @@ from aura.tools.search import (  # noqa: E402, F401
     search_by_region,
     search_structured,
 )
+from aura.tools.spatial import find_map_sheets, map_sheet  # noqa: E402, F401
 from aura.tools.suggest import suggest_questions  # noqa: E402, F401

--- a/src/aura/server.py
+++ b/src/aura/server.py
@@ -9,6 +9,8 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from fastmcp import Context, FastMCP
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 from aura.config import is_readonly
 from aura.database import (
@@ -48,6 +50,12 @@ WRITE_TOOL_NAMES = frozenset(
         "populate_reference",
     }
 )
+
+
+def health_payload(conn: sqlite3.Connection) -> dict[str, Any]:
+    """Rakenna /health-vastauksen runko: tila + datasettien määrä (DB-tarkistus)."""
+    count = conn.execute("SELECT COUNT(*) FROM datasets").fetchone()[0]
+    return {"status": "ok", "datasets": int(count)}
 
 
 def apply_readonly_gating(
@@ -104,6 +112,16 @@ mcp = FastMCP(
     ),
     lifespan=_lifespan,
 )
+
+
+@mcp.custom_route("/health", methods=["GET"])
+async def _health_route(request: Request) -> JSONResponse:
+    """Kevyt terveystarkistus App Runnerille: 200 + datasettien määrä."""
+    conn = get_connection(readonly=is_readonly())
+    try:
+        return JSONResponse(health_payload(conn))
+    finally:
+        conn.close()
 
 
 _module_conn: sqlite3.Connection | None = None

--- a/src/aura/server.py
+++ b/src/aura/server.py
@@ -278,5 +278,9 @@ from aura.tools.search import (  # noqa: E402, F401
     search_by_region,
     search_structured,
 )
-from aura.tools.spatial import find_map_sheets, map_sheet  # noqa: E402, F401
+from aura.tools.spatial import (  # noqa: E402, F401
+    find_map_sheets,
+    map_sheet,
+    municipality_bbox,
+)
 from aura.tools.suggest import suggest_questions  # noqa: E402, F401

--- a/src/aura/server.py
+++ b/src/aura/server.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from fastmcp import Context, FastMCP
 
+from aura.config import is_readonly
 from aura.database import (
     get_connection,
     init_db,
@@ -22,14 +23,51 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def _lifespan(server: FastMCP) -> AsyncIterator[dict[str, Any]]:
     """Hallitse tietokantayhteyttä serverin elinkaaren ajan."""
-    conn = get_connection(check_same_thread=False)
-    init_db(conn)
+    readonly = is_readonly()
+    conn = get_connection(check_same_thread=False, readonly=readonly)
+    if not readonly:
+        # init_db kirjoittaa (migraatiot/skeema) → ohitetaan read-only-moodissa.
+        init_db(conn)
     yso = YsoClient()
     try:
         yield {"db": conn, "findings": [], "yso": yso}
     finally:
         await yso.close()
         conn.close()
+
+
+# Toolit jotka kirjoittavat tietokantaan → poistetaan read-only-remotessa.
+# (log_finding/list_findings ovat session-muistia, eivät kirjoita kantaan.)
+WRITE_TOOL_NAMES = frozenset(
+    {
+        "harvest",
+        "probe_sizes",
+        "enrich",
+        "batch_enrich",
+        "save_session_findings",
+        "populate_reference",
+    }
+)
+
+
+def apply_readonly_gating(
+    server: FastMCP | None = None, *, readonly: bool | None = None
+) -> list[str]:
+    """Poista kirjoittavat toolit kun server on read-only-moodissa.
+
+    Palauttaa poistettujen toolien nimet. Ei tee mitään jos ei read-only.
+    """
+    if server is None:
+        server = mcp
+    if readonly is None:
+        readonly = is_readonly()
+    if not readonly:
+        return []
+    removed: list[str] = []
+    for name in WRITE_TOOL_NAMES:
+        server.local_provider.remove_tool(name)
+        removed.append(name)
+    return removed
 
 
 mcp = FastMCP(

--- a/src/aura/tools/__init__.py
+++ b/src/aura/tools/__init__.py
@@ -15,6 +15,7 @@ from aura.tools import (  # noqa: F401
     reference,
     research,
     search,
+    spatial,
     suggest,
 )
 
@@ -29,5 +30,6 @@ __all__ = [
     "reference",
     "research",
     "search",
+    "spatial",
     "suggest",
 ]

--- a/src/aura/tools/spatial.py
+++ b/src/aura/tools/spatial.py
@@ -1,0 +1,165 @@
+"""Paikkatietotyökalut (#136): map_sheet, find_map_sheets.
+
+Palvelevat ref_map_sheets-taulusta (kannassa jo bbox EPSG:3067) → toimivat myös
+read-only-remotessa. Agentti voi rajata WFS/WCS/OGC-kyselyt karttalehden bbox:illa.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from fastmcp import Context
+
+import aura.server as _server
+from aura.server import mcp
+
+
+def _map_sheet_data(conn: sqlite3.Connection, sheet_id: str) -> dict[str, Any] | None:
+    """Hae karttalehden tiedot (bbox, centroid, mittakaava) kannasta."""
+    row = conn.execute(
+        """
+        SELECT id, scale, min_x, min_y, max_x, max_y, centroid_x, centroid_y
+        FROM ref_map_sheets WHERE id = ? COLLATE NOCASE
+        """,
+        (sheet_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return {
+        "id": row["id"],
+        "scale": row["scale"],
+        "min_x": row["min_x"],
+        "min_y": row["min_y"],
+        "max_x": row["max_x"],
+        "max_y": row["max_y"],
+        "centroid_x": row["centroid_x"],
+        "centroid_y": row["centroid_y"],
+    }
+
+
+def _bbox_str(d: dict[str, Any]) -> str:
+    """Valmis WFS/WCS-bbox EPSG:3067:ssä: minx,miny,maxx,maxy,EPSG:3067."""
+    return f"{d['min_x']},{d['min_y']},{d['max_x']},{d['max_y']},EPSG:3067"
+
+
+def _format_map_sheet(d: dict[str, Any]) -> str:
+    return (
+        f"Karttalehti {d['id']} (mittakaavataso {d['scale']}, EPSG:3067)\n"
+        f"  bbox (WFS/WCS): {_bbox_str(d)}\n"
+        f"  centroidi: {d['centroid_x']},{d['centroid_y']}\n\n"
+        f"Käytä bbox-arvoa aluerajauksena WFS/WCS/OGC-kyselyssä."
+    )
+
+
+def _parse_floats(text: str, count: int) -> list[float] | None:
+    """Pilko pilkuilla erotettu lukumerkkijono (esim. bbox tai piste)."""
+    parts = [p.strip() for p in text.split(",") if p.strip()]
+    if len(parts) != count:
+        return None
+    try:
+        return [float(p) for p in parts]
+    except ValueError:
+        return None
+
+
+def _find_map_sheets(
+    conn: sqlite3.Connection,
+    *,
+    scale: str,
+    bbox: list[float] | None = None,
+    point: list[float] | None = None,
+    prefix: str | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Hae karttalehdet mittakaavatasolta suodattimilla (bbox/piste/prefiksi)."""
+    sql = (
+        "SELECT id, scale, min_x, min_y, max_x, max_y, centroid_x, centroid_y "
+        "FROM ref_map_sheets WHERE scale = ?"
+    )
+    params: list[Any] = [scale]
+
+    if prefix:
+        sql += " AND id LIKE ? COLLATE NOCASE"
+        params.append(f"{prefix}%")
+    if bbox:
+        # Leikkaavuus: EI (lehti kokonaan bbox:n ulkopuolella)
+        sql += " AND NOT (max_x < ? OR min_x > ? OR max_y < ? OR min_y > ?)"
+        params.extend([bbox[0], bbox[2], bbox[1], bbox[3]])
+    if point:
+        sql += " AND min_x <= ? AND max_x >= ? AND min_y <= ? AND max_y >= ?"
+        params.extend([point[0], point[0], point[1], point[1]])
+
+    sql += " ORDER BY id LIMIT ?"
+    params.append(limit)
+    rows = conn.execute(sql, params).fetchall()
+    return [dict(r) for r in rows]
+
+
+@mcp.tool()
+def find_map_sheets(
+    scale: str,
+    bbox: str | None = None,
+    point: str | None = None,
+    prefix: str | None = None,
+    limit: int = 50,
+    ctx: Context | None = None,
+) -> str:
+    """Etsi karttalehdet jotka osuvat alueelle (aluerajauksen apu).
+
+    Anna **vähintään yksi** suodatin: ``bbox``, ``point`` tai ``prefix``.
+
+    Args:
+        scale: Mittakaavataso: 'utm200' (yleiskatsaus), 'utm50' (maakunnat),
+            'utm25' (kaupungit), 'utm10' (yksityiskohdat).
+        bbox: Rajauslaatikko EPSG:3067: 'minx,miny,maxx,maxy' — palauttaa leikkaavat lehdet.
+        point: Piste EPSG:3067: 'x,y' — palauttaa lehden joka sisältää pisteen.
+        prefix: Tunnusprefiksi (esim. 'L413') — hierarkkinen rajaus.
+        limit: Tulosten enimmäismäärä (oletus 50).
+    """
+    if not (bbox or point or prefix):
+        return (
+            "Anna vähintään yksi suodatin: bbox ('minx,miny,maxx,maxy'), "
+            "point ('x,y') tai prefix (esim. 'L413')."
+        )
+
+    bbox_vals = _parse_floats(bbox, 4) if bbox else None
+    if bbox and bbox_vals is None:
+        return "Virheellinen bbox. Muoto: 'minx,miny,maxx,maxy' (EPSG:3067)."
+    point_vals = _parse_floats(point, 2) if point else None
+    if point and point_vals is None:
+        return "Virheellinen point. Muoto: 'x,y' (EPSG:3067)."
+
+    conn = _server._get_conn(ctx)
+    sheets = _find_map_sheets(
+        conn,
+        scale=scale.strip(),
+        bbox=bbox_vals,
+        point=point_vals,
+        prefix=prefix.strip() if prefix else None,
+        limit=limit,
+    )
+    if not sheets:
+        return f"Ei karttalehtiä mittakaavatasolla '{scale}' annetuilla suodattimilla."
+
+    lines = [f"Löytyi {len(sheets)} karttalehteä (mittakaavataso {scale}, EPSG:3067):"]
+    for d in sheets:
+        lines.append(f"  {d['id']}: bbox {_bbox_str(d)}")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def map_sheet(sheet_id: str, ctx: Context | None = None) -> str:
+    """Hae karttalehden bbox (EPSG:3067) aluerajaukseen.
+
+    Palauttaa karttalehden rajauslaatikon valmiina WFS/WCS-kyselyyn. Karttalehdet
+    ovat MML:n TM35-ruutuja (esim. 'L4133', 'L4133A').
+
+    Args:
+        sheet_id: Karttalehtitunnus (esim. 'L4133A'). Kirjainkoolla ei väliä.
+    """
+    conn = _server._get_conn(ctx)
+    data = _map_sheet_data(conn, sheet_id.strip())
+    if data is None:
+        return f"Karttalehteä '{sheet_id}' ei löytynyt."
+    return _format_map_sheet(data)

--- a/src/aura/tools/spatial.py
+++ b/src/aura/tools/spatial.py
@@ -148,6 +148,50 @@ def find_map_sheets(
     return "\n".join(lines)
 
 
+def _municipality_row(conn: sqlite3.Connection, query: str) -> sqlite3.Row | None:
+    """Hae kunta nimellä (fi/sv) tai kuntakoodilla."""
+    row: sqlite3.Row | None
+    if query.isdigit() and len(query) <= 3:
+        code = query.zfill(3)
+        row = conn.execute(
+            "SELECT * FROM ref_municipalities WHERE code = ?", (code,)
+        ).fetchone()
+    else:
+        row = conn.execute(
+            "SELECT * FROM ref_municipalities "
+            "WHERE name_fi = ? COLLATE NOCASE OR name_sv = ? COLLATE NOCASE",
+            (query, query),
+        ).fetchone()
+    return row
+
+
+@mcp.tool()
+def municipality_bbox(query: str, ctx: Context | None = None) -> str:
+    """Hae kunnan bbox (EPSG:3067) aluerajaukseen.
+
+    Palauttaa kunnan rajauslaatikon valmiina WFS/WCS-kyselyyn. Voit ketjuttaa:
+    hae kunnan bbox → syötä se ``find_map_sheets(bbox=...)``-kutsuun.
+
+    Args:
+        query: Kunnan nimi (fi/sv) tai kuntakoodi (esim. 'Helsinki' tai '091').
+    """
+    conn = _server._get_conn(ctx)
+    row = _municipality_row(conn, query.strip())
+    if row is None:
+        return f"Kuntaa '{query}' ei löytynyt."
+    if row["min_x"] is None:
+        return (
+            f"Kunnan {row['name_fi']} bbox-tietoja ei ole ladattu. "
+            "Aja ensin: `populate_reference('municipality_bbox')`."
+        )
+    bbox = f"{row['min_x']},{row['min_y']},{row['max_x']},{row['max_y']},EPSG:3067"
+    return (
+        f"Kunta {row['name_fi']} ({row['code']}, EPSG:3067)\n"
+        f"  bbox (WFS/WCS): {bbox}\n\n"
+        f"Käytä bbox-arvoa aluerajauksena tai find_map_sheets(bbox=...)-kutsussa."
+    )
+
+
 @mcp.tool()
 def map_sheet(sheet_id: str, ctx: Context | None = None) -> str:
     """Hae karttalehden bbox (EPSG:3067) aluerajaukseen.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,17 @@
+"""Testit ajonaikaiselle konfiguraatiolle (#135)."""
+
+from aura.config import is_readonly
+
+
+def test_readonly_false_when_unset() -> None:
+    assert is_readonly(env={}) is False
+
+
+def test_readonly_true_for_truthy_values() -> None:
+    for val in ("1", "true", "TRUE", "yes", "on", " 1 "):
+        assert is_readonly(env={"AURA_READONLY": val}) is True, val
+
+
+def test_readonly_false_for_falsy_values() -> None:
+    for val in ("0", "false", "no", "off", ""):
+        assert is_readonly(env={"AURA_READONLY": val}) is False, val

--- a/tests/test_health_endpoint.py
+++ b/tests/test_health_endpoint.py
@@ -1,0 +1,23 @@
+"""Testit /health-endpointille ja sen payloadille (#138)."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from aura.server import health_payload
+
+
+def _db_with_datasets(n: int) -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE datasets (id INTEGER PRIMARY KEY)")
+    conn.executemany("INSERT INTO datasets (id) VALUES (?)", [(i,) for i in range(n)])
+    conn.commit()
+    return conn
+
+
+def test_health_payload_reports_ok_and_count() -> None:
+    conn = _db_with_datasets(3)
+    try:
+        assert health_payload(conn) == {"status": "ok", "datasets": 3}
+    finally:
+        conn.close()

--- a/tests/test_populator_municipality_bbox.py
+++ b/tests/test_populator_municipality_bbox.py
@@ -1,0 +1,44 @@
+"""Testit kuntien bbox-populaattorille (#136)."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from aura.populators.municipality_bbox import MunicipalityBboxPopulator
+
+
+def _db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_apply_bboxes_updates_matching_municipalities() -> None:
+    pop = MunicipalityBboxPopulator(conn=_db())  # __init__ ajaa migraatiot
+    pop.conn.execute(
+        "INSERT INTO ref_municipalities (code, name_fi, name_sv) "
+        "VALUES ('091','Helsinki','Helsingfors')"
+    )
+    pop.conn.commit()
+
+    updated = pop._apply_bboxes({"091": (25490000.0, 6665000.0, 25515000.0, 6690000.0)})
+
+    assert updated == 1
+    row = pop.conn.execute(
+        "SELECT min_x, max_y FROM ref_municipalities WHERE code = '091'"
+    ).fetchone()
+    assert row["min_x"] == 25490000.0
+    assert row["max_y"] == 6690000.0
+
+
+def test_apply_bboxes_ignores_unknown_codes() -> None:
+    pop = MunicipalityBboxPopulator(conn=_db())
+    pop.conn.execute(
+        "INSERT INTO ref_municipalities (code, name_fi, name_sv) "
+        "VALUES ('091','Helsinki','Helsingfors')"
+    )
+    pop.conn.commit()
+
+    updated = pop._apply_bboxes({"999": (1.0, 2.0, 3.0, 4.0)})
+
+    assert updated == 0

--- a/tests/test_readonly_db.py
+++ b/tests/test_readonly_db.py
@@ -1,0 +1,40 @@
+"""Testit read-only-tietokantayhteydelle (#135)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from aura.database import get_connection
+
+
+def _seed(path: Path) -> None:
+    conn = get_connection(path)
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+    conn.execute("INSERT INTO t (v) VALUES ('a')")
+    conn.commit()
+    conn.close()
+
+
+def test_readonly_connection_can_read(tmp_path: Path) -> None:
+    db = tmp_path / "ro.db"
+    _seed(db)
+    conn = get_connection(db, readonly=True)
+    try:
+        assert conn.execute("SELECT v FROM t WHERE id = 1").fetchone()[0] == "a"
+    finally:
+        conn.close()
+
+
+def test_readonly_connection_rejects_writes(tmp_path: Path) -> None:
+    db = tmp_path / "ro.db"
+    _seed(db)
+    conn = get_connection(db, readonly=True)
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("INSERT INTO t (v) VALUES ('b')")
+            conn.commit()
+    finally:
+        conn.close()

--- a/tests/test_readonly_gating.py
+++ b/tests/test_readonly_gating.py
@@ -1,0 +1,52 @@
+"""Testit read-only-toolien gateykselle (#135)."""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastmcp import FastMCP
+
+from aura.server import WRITE_TOOL_NAMES, apply_readonly_gating
+
+
+def _tool_names(server: FastMCP) -> set[str]:
+    tools = asyncio.run(server.list_tools())
+    return {t.name for t in tools}
+
+
+def _build_server() -> FastMCP:
+    server = FastMCP("test")
+    for name in [*WRITE_TOOL_NAMES, "search", "stats"]:
+        @server.tool(name=name)
+        def _fn() -> str:
+            return "ok"
+    return server
+
+
+def test_gating_removes_write_tools_when_readonly() -> None:
+    server = _build_server()
+    removed = apply_readonly_gating(server, readonly=True)
+    names = _tool_names(server)
+    assert names == {"search", "stats"}
+    assert set(removed) == set(WRITE_TOOL_NAMES)
+
+
+def test_gating_keeps_all_tools_when_not_readonly() -> None:
+    server = _build_server()
+    removed = apply_readonly_gating(server, readonly=False)
+    names = _tool_names(server)
+    assert WRITE_TOOL_NAMES <= names
+    assert removed == []
+
+
+def test_write_tool_names_are_the_expected_set() -> None:
+    assert WRITE_TOOL_NAMES == frozenset(
+        {
+            "harvest",
+            "probe_sizes",
+            "enrich",
+            "batch_enrich",
+            "save_session_findings",
+            "populate_reference",
+        }
+    )

--- a/tests/test_readonly_http_integration.py
+++ b/tests/test_readonly_http_integration.py
@@ -1,0 +1,64 @@
+"""Integraatiotesti: read-only-remote piilottaa kirjoittavat toolit (#135)."""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+
+import pytest
+from fastmcp import Client
+
+from aura.server import WRITE_TOOL_NAMES
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+@pytest.fixture
+def readonly_server() -> Iterator[str]:
+    port = _free_port()
+    env = {**os.environ, "AURA_READONLY": "1"}
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "aura.cli", "serve", "--http",
+         "--host", "127.0.0.1", "--port", str(port)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
+    try:
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                out = proc.stdout.read().decode() if proc.stdout else ""
+                raise RuntimeError(f"server kuoli ennen valmistumista:\n{out}")
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                if s.connect_ex(("127.0.0.1", port)) == 0:
+                    break
+            time.sleep(0.2)
+        else:
+            raise RuntimeError("server ei käynnistynyt ajoissa")
+        yield f"http://127.0.0.1:{port}/mcp"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+async def test_write_tools_absent_read_tools_present(readonly_server: str) -> None:
+    async with Client(readonly_server) as client:
+        tools = await client.list_tools()
+    names = {t.name for t in tools}
+    # Kirjoittavat toolit eivät saa näkyä
+    assert names.isdisjoint(WRITE_TOOL_NAMES), names & WRITE_TOOL_NAMES
+    # Lukutoolit toimivat normaalisti
+    assert "search" in names
+    assert "stats" in names

--- a/tests/test_serve_cli.py
+++ b/tests/test_serve_cli.py
@@ -1,0 +1,45 @@
+"""Testit serve-komennon CLI-johdotukselle (#134).
+
+``mcp.run()`` blokkaa, joten se mockataan kwargsien talteenottoon — testi
+varmistaa että argumentit kulkevat resoluution läpi oikein run-kutsuun.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import aura.server
+from aura import cli
+
+
+@pytest.fixture
+def captured_run(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    def fake_run(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(aura.server.mcp, "run", fake_run)
+    return captured
+
+
+def test_serve_stdio_default(
+    monkeypatch: pytest.MonkeyPatch, captured_run: dict[str, Any]
+) -> None:
+    monkeypatch.setattr("sys.argv", ["aura", "serve"])
+    cli.main()
+    assert captured_run == {"transport": "stdio"}
+
+
+def test_serve_http_flag(
+    monkeypatch: pytest.MonkeyPatch, captured_run: dict[str, Any]
+) -> None:
+    monkeypatch.setattr("sys.argv", ["aura", "serve", "--http", "--port", "8123"])
+    cli.main()
+    assert captured_run["transport"] == "http"
+    assert captured_run["port"] == 8123
+    assert captured_run["host"] == "127.0.0.1"
+    assert captured_run["path"] == "/mcp"
+    assert captured_run["stateless_http"] is True

--- a/tests/test_serve_config.py
+++ b/tests/test_serve_config.py
@@ -1,0 +1,58 @@
+"""Testit serve-komennon transport-konfiguraation resoluutiolle (#134)."""
+
+from aura.serve import resolve_serve_config
+
+
+def test_default_is_stdio() -> None:
+    cfg = resolve_serve_config(http=False, host=None, port=None, env={})
+    assert cfg.transport == "stdio"
+    assert cfg.run_args() == {"transport": "stdio"}
+
+
+def test_http_defaults() -> None:
+    cfg = resolve_serve_config(http=True, host=None, port=None, env={})
+    assert cfg.transport == "http"
+    assert cfg.host == "127.0.0.1"
+    assert cfg.port == 8000
+    assert cfg.path == "/mcp"
+    assert cfg.stateless_http is True
+    assert cfg.run_args() == {
+        "transport": "http",
+        "host": "127.0.0.1",
+        "port": 8000,
+        "path": "/mcp",
+        "stateless_http": True,
+    }
+
+
+def test_http_reads_host_and_port_from_env() -> None:
+    cfg = resolve_serve_config(
+        http=True,
+        host=None,
+        port=None,
+        env={"AURA_HTTP_HOST": "0.0.0.0", "AURA_HTTP_PORT": "9001"},
+    )
+    assert cfg.host == "0.0.0.0"
+    assert cfg.port == 9001
+
+
+def test_explicit_args_override_env() -> None:
+    cfg = resolve_serve_config(
+        http=True,
+        host="0.0.0.0",
+        port=8080,
+        env={"AURA_HTTP_HOST": "127.0.0.1", "AURA_HTTP_PORT": "9001"},
+    )
+    assert cfg.host == "0.0.0.0"
+    assert cfg.port == 8080
+
+
+def test_stdio_ignores_http_settings() -> None:
+    cfg = resolve_serve_config(
+        http=False,
+        host="0.0.0.0",
+        port=8080,
+        env={"AURA_HTTP_PORT": "9001"},
+    )
+    assert cfg.transport == "stdio"
+    assert cfg.run_args() == {"transport": "stdio"}

--- a/tests/test_serve_http_integration.py
+++ b/tests/test_serve_http_integration.py
@@ -11,6 +11,7 @@ import sys
 import time
 from collections.abc import Iterator
 
+import httpx
 import pytest
 from fastmcp import Client
 
@@ -57,3 +58,12 @@ async def test_initialize_and_list_tools_over_http(http_server: str) -> None:
         tools = await client.list_tools()
     names = {t.name for t in tools}
     assert "search" in names
+
+
+def test_health_endpoint_returns_200(http_server: str) -> None:
+    health_url = http_server.replace("/mcp", "/health")
+    resp = httpx.get(health_url, timeout=10)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["datasets"] >= 0

--- a/tests/test_serve_http_integration.py
+++ b/tests/test_serve_http_integration.py
@@ -1,0 +1,59 @@
+"""Integraatiotesti: serve --http käynnistyy ja vastaa MCP-kutsuun HTTP:n yli (#134).
+
+Käynnistää oikean serverin aliprosessina ja yhdistää FastMCP-clientilla.
+"""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+
+import pytest
+from fastmcp import Client
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+@pytest.fixture
+def http_server() -> Iterator[str]:
+    port = _free_port()
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "aura.cli", "serve", "--http",
+         "--host", "127.0.0.1", "--port", str(port)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    try:
+        # Odota että portti kuuntelee
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                out = proc.stdout.read().decode() if proc.stdout else ""
+                raise RuntimeError(f"server kuoli ennen valmistumista:\n{out}")
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                if s.connect_ex(("127.0.0.1", port)) == 0:
+                    break
+            time.sleep(0.2)
+        else:
+            raise RuntimeError("server ei käynnistynyt ajoissa")
+        yield f"http://127.0.0.1:{port}/mcp"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+async def test_initialize_and_list_tools_over_http(http_server: str) -> None:
+    async with Client(http_server) as client:
+        tools = await client.list_tools()
+    names = {t.name for t in tools}
+    assert "search" in names

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -1,0 +1,105 @@
+"""Testit paikkatietotyökaluille (#136): map_sheet, find_map_sheets."""
+
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import patch
+
+
+def _db_with_map_sheets() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE ref_map_sheets (
+            id TEXT, scale TEXT,
+            min_x REAL, min_y REAL, max_x REAL, max_y REAL,
+            centroid_x REAL, centroid_y REAL, updated_at TEXT
+        )
+        """
+    )
+    rows = [
+        # id, scale, minx, miny, maxx, maxy, cx, cy
+        ("K2", "utm200", -76000.0, 6570000.0, 116000.0, 6666000.0, 20000.0, 6618000.0),
+        ("L4133", "utm25", 340000.0, 6820000.0, 352000.0, 6826000.0, 346000.0, 6823000.0),
+        ("L4133A", "utm10", 340000.0, 6820000.0, 346000.0, 6823000.0, 343000.0, 6821500.0),
+        ("L4134", "utm25", 352000.0, 6820000.0, 364000.0, 6826000.0, 358000.0, 6823000.0),
+    ]
+    conn.executemany(
+        "INSERT INTO ref_map_sheets "
+        "(id, scale, min_x, min_y, max_x, max_y, centroid_x, centroid_y) "
+        "VALUES (?,?,?,?,?,?,?,?)",
+        rows,
+    )
+    conn.commit()
+    return conn
+
+
+def test_map_sheet_returns_bbox_for_known_sheet() -> None:
+    from aura.server import map_sheet
+
+    conn = _db_with_map_sheets()
+    with patch("aura.server._get_conn", return_value=conn):
+        out = map_sheet("L4133")
+    # Sisältää valmiin EPSG:3067 bbox-merkkijonon WFS/WCS-kyselyyn
+    assert "340000" in out and "6820000" in out and "352000" in out and "6826000" in out
+    assert "EPSG:3067" in out
+    assert "utm25" in out
+
+
+def test_map_sheet_is_case_insensitive() -> None:
+    from aura.server import map_sheet
+
+    conn = _db_with_map_sheets()
+    with patch("aura.server._get_conn", return_value=conn):
+        out = map_sheet("l4133")
+    assert "340000" in out
+
+
+def test_map_sheet_unknown_returns_message() -> None:
+    from aura.server import map_sheet
+
+    conn = _db_with_map_sheets()
+    with patch("aura.server._get_conn", return_value=conn):
+        out = map_sheet("XYZ999")
+    assert "ei löytynyt" in out.lower() or "ei löydy" in out.lower()
+
+
+def test_find_map_sheets_by_prefix_and_scale() -> None:
+    from aura.server import find_map_sheets
+
+    conn = _db_with_map_sheets()
+    with patch("aura.server._get_conn", return_value=conn):
+        out = find_map_sheets(scale="utm25", prefix="L413")
+    assert "L4133" in out
+    assert "L4134" in out
+    assert "L4133A" not in out  # eri mittakaava (utm10)
+
+
+def test_find_map_sheets_by_bbox_intersection() -> None:
+    from aura.server import find_map_sheets
+
+    conn = _db_with_map_sheets()
+    with patch("aura.server._get_conn", return_value=conn):
+        out = find_map_sheets(scale="utm25", bbox="345000,6821000,346000,6822000")
+    assert "L4133" in out
+    assert "L4134" not in out  # ei leikkaa
+
+
+def test_find_map_sheets_by_point_containment() -> None:
+    from aura.server import find_map_sheets
+
+    conn = _db_with_map_sheets()
+    with patch("aura.server._get_conn", return_value=conn):
+        out = find_map_sheets(scale="utm25", point="358000,6823000")
+    assert "L4134" in out
+    assert "L4133" not in out
+
+
+def test_find_map_sheets_requires_a_filter() -> None:
+    from aura.server import find_map_sheets
+
+    conn = _db_with_map_sheets()
+    with patch("aura.server._get_conn", return_value=conn):
+        out = find_map_sheets(scale="utm25")
+    assert "anna" in out.lower() or "vähintään" in out.lower() or "bbox" in out.lower()

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -103,3 +103,65 @@ def test_find_map_sheets_requires_a_filter() -> None:
     with patch("aura.server._get_conn", return_value=conn):
         out = find_map_sheets(scale="utm25")
     assert "anna" in out.lower() or "vähintään" in out.lower() or "bbox" in out.lower()
+
+
+def _db_with_municipalities() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE ref_municipalities (
+            code TEXT PRIMARY KEY, name_fi TEXT, name_sv TEXT,
+            min_x REAL, min_y REAL, max_x REAL, max_y REAL
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO ref_municipalities "
+        "(code, name_fi, name_sv, min_x, min_y, max_x, max_y) "
+        "VALUES ('091','Helsinki','Helsingfors',25490000.0,6665000.0,25515000.0,6690000.0)"
+    )
+    conn.execute(
+        "INSERT INTO ref_municipalities (code, name_fi, name_sv) "
+        "VALUES ('992','Bbox-puuttuu','-')"
+    )
+    conn.commit()
+    return conn
+
+
+def test_municipality_bbox_by_name() -> None:
+    from aura.server import municipality_bbox
+
+    conn = _db_with_municipalities()
+    with patch("aura.server._get_conn", return_value=conn):
+        out = municipality_bbox("Helsinki")
+    assert "25490000" in out and "6665000" in out
+    assert "EPSG:3067" in out
+
+
+def test_municipality_bbox_by_code() -> None:
+    from aura.server import municipality_bbox
+
+    conn = _db_with_municipalities()
+    with patch("aura.server._get_conn", return_value=conn):
+        out = municipality_bbox("91")  # zero-pad → 091
+    assert "Helsinki" in out
+    assert "25515000" in out
+
+
+def test_municipality_bbox_missing_data_message() -> None:
+    from aura.server import municipality_bbox
+
+    conn = _db_with_municipalities()
+    with patch("aura.server._get_conn", return_value=conn):
+        out = municipality_bbox("Bbox-puuttuu")
+    assert "populate_reference" in out or "ei ole" in out.lower()
+
+
+def test_municipality_bbox_unknown() -> None:
+    from aura.server import municipality_bbox
+
+    conn = _db_with_municipalities()
+    with patch("aura.server._get_conn", return_value=conn):
+        out = municipality_bbox("Atlantis")
+    assert "ei löytynyt" in out.lower() or "ei löydy" in out.lower()


### PR DESCRIPTION
## Remote MCP @ AWS — sovelluspuoli + paketointi

Toteuttaa epicin #133 ensimmäiset 5 issueta. Aura on nyt remote-valmis: streamable HTTP, read-only-gateys, health-endpoint, kontti ja paikkatietotyökalut. Kaikki TDD:llä.

### Mukana
- **#134** `aura serve --http` — FastMCP streamable HTTP (`/mcp`, stateless); stdio säilyy oletuksena.
- **#135** Read-only-moodi (`AURA_READONLY=1`) — kirjoittavat toolit eivät rekisteröidy, SQLite `mode=ro`.
- **#138** `/health`-endpoint — 200 + datasettien määrä (App Runner health check).
- **#139** Dockerfile + .dockerignore — `python:3.11-slim`, vain `aura.db`, non-root, content size 119 MB; build + kontti-smoke todennettu.
- **#136** Paikkatietotyökalut — `map_sheet`, `find_map_sheets` (kannasta), `municipality_bbox` (migraatio 017 + populaattori, 308/308 kuntaa populoitu).

### Suunnitelma
`docs/superpowers/specs/2026-06-06-aws-remote-mcp-design.md` (mukana tässä PR:ssä).

### Testaus
872 passed, 0 failed (55 deselattu = ennestään failaavat päivämäärätestit). ruff puhdas; mypy puhdas uusille tiedostoille (2 ennestään olevaa virhettä quality.py:ssä).

Closes #134
Closes #135
Closes #136
Closes #138
Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)
